### PR TITLE
Feat: implementar foto de perfil con Active Storage

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,13 @@
+class Users::RegistrationsController < Devise::RegistrationsController
+  before_action :configure_account_update_params, only: [:update]
+
+  protected
+
+  def configure_account_update_params
+    devise_parameter_sanitizer.permit(:account_update, keys: [:avatar, :name])
+  end
+
+  def after_update_path_for(resource)
+    edit_user_registration_path
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,9 @@ class User < ApplicationRecord
   # Enums
   enum :role, { admin: 0, consultant: 1, client_user: 2 }
 
+  # Avatar
+  has_one_attached :avatar
+
   # Associations
   belongs_to :client, optional: true
   has_many :created_tickets, class_name: 'Ticket', foreign_key: 'created_by_id', dependent: :nullify

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,43 +1,84 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<div class="max-w-2xl mx-auto p-6">
+  <h2 class="text-2xl font-bold text-[#c9d1d9] mb-6">Edit Profile</h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, multipart: true, class: "space-y-6" }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+    <%# Avatar Section %>
+    <div class="bg-[#161b22] border border-[#30363d] rounded-lg p-6">
+      <h3 class="text-lg font-semibold text-[#c9d1d9] mb-4">Profile Photo</h3>
+      <div class="flex items-center space-x-6">
+        <div class="flex-shrink-0">
+          <% if resource.avatar.attached? %>
+            <%= image_tag url_for(resource.avatar), class: "w-24 h-24 rounded-full object-cover border-2 border-[#30363d]", alt: resource.name %>
+          <% else %>
+            <div class="w-24 h-24 rounded-full bg-[#21262d] border-2 border-[#30363d] flex items-center justify-center">
+              <span class="text-3xl font-bold text-[#58a6ff]"><%= resource.name&.first&.upcase %></span>
+            </div>
+          <% end %>
+        </div>
+        <div class="flex-1">
+          <%= f.label :avatar, "Upload new photo", class: "block text-sm font-medium text-[#8b949e] mb-2" %>
+          <%= f.file_field :avatar, accept: "image/*", class: "block w-full text-sm text-[#8b949e] file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-[#21262d] file:text-[#58a6ff] hover:file:bg-[#30363d] cursor-pointer" %>
+          <p class="mt-1 text-xs text-[#8b949e]">PNG, JPG, GIF up to 5MB</p>
+        </div>
+      </div>
+    </div>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+    <%# Account Info %>
+    <div class="bg-[#161b22] border border-[#30363d] rounded-lg p-6 space-y-4">
+      <h3 class="text-lg font-semibold text-[#c9d1d9] mb-4">Account Info</h3>
+
+      <div>
+        <%= f.label :email, class: "block text-sm font-medium text-[#8b949e] mb-1" %>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email",
+            class: "w-full bg-[#0d1117] border border-[#30363d] rounded-lg px-4 py-2 text-[#c9d1d9] focus:outline-none focus:border-[#58a6ff] focus:ring-1 focus:ring-[#58a6ff]" %>
+        <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+          <p class="mt-1 text-xs text-[#f0883e]">Pending confirmation for: <%= resource.unconfirmed_email %></p>
+        <% end %>
+      </div>
+    </div>
+
+    <%# Password Section %>
+    <div class="bg-[#161b22] border border-[#30363d] rounded-lg p-6 space-y-4">
+      <h3 class="text-lg font-semibold text-[#c9d1d9] mb-4">Change Password</h3>
+      <p class="text-xs text-[#8b949e] -mt-2">Leave blank to keep current password</p>
+
+      <div>
+        <%= f.label :password, class: "block text-sm font-medium text-[#8b949e] mb-1" %>
+        <%= f.password_field :password, autocomplete: "new-password",
+            class: "w-full bg-[#0d1117] border border-[#30363d] rounded-lg px-4 py-2 text-[#c9d1d9] focus:outline-none focus:border-[#58a6ff] focus:ring-1 focus:ring-[#58a6ff]" %>
+        <% if @minimum_password_length %>
+          <p class="mt-1 text-xs text-[#8b949e]">Minimum <%= @minimum_password_length %> characters</p>
+        <% end %>
+      </div>
+
+      <div>
+        <%= f.label :password_confirmation, class: "block text-sm font-medium text-[#8b949e] mb-1" %>
+        <%= f.password_field :password_confirmation, autocomplete: "new-password",
+            class: "w-full bg-[#0d1117] border border-[#30363d] rounded-lg px-4 py-2 text-[#c9d1d9] focus:outline-none focus:border-[#58a6ff] focus:ring-1 focus:ring-[#58a6ff]" %>
+      </div>
+
+      <div>
+        <%= f.label :current_password, class: "block text-sm font-medium text-[#8b949e] mb-1" %>
+        <%= f.password_field :current_password, autocomplete: "current-password",
+            class: "w-full bg-[#0d1117] border border-[#30363d] rounded-lg px-4 py-2 text-[#c9d1d9] focus:outline-none focus:border-[#58a6ff] focus:ring-1 focus:ring-[#58a6ff]" %>
+        <p class="mt-1 text-xs text-[#8b949e]">Required to confirm your changes</p>
+      </div>
+    </div>
+
+    <div class="flex items-center justify-between">
+      <%= f.submit "Save Changes", class: "bg-[#238636] hover:bg-[#2ea043] text-white font-medium px-6 py-2 rounded-lg transition-colors cursor-pointer" %>
+      <%= link_to "Back", :back, class: "text-[#8b949e] hover:text-[#c9d1d9] text-sm transition-colors" %>
+    </div>
   <% end %>
 
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
-    <% end %>
+  <div class="mt-8 bg-[#161b22] border border-[#f85149]/30 rounded-lg p-6">
+    <h3 class="text-lg font-semibold text-[#f85149] mb-2">Danger Zone</h3>
+    <p class="text-sm text-[#8b949e] mb-4">Once you delete your account, there is no going back.</p>
+    <%= button_to "Cancel my account", registration_path(resource_name),
+        data: { turbo_confirm: "Are you sure you want to delete your account?" },
+        method: :delete,
+        class: "bg-[#f85149]/10 hover:bg-[#f85149]/20 border border-[#f85149]/30 text-[#f85149] font-medium px-4 py-2 rounded-lg transition-colors cursor-pointer text-sm" %>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-
-<%= link_to "Back", :back %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,7 +40,16 @@
         <div class="hidden lg:flex w-64 bg-[#161b22] border-r border-[#30363d] flex-col" data-sidebar-target="sidebar">
           <div class="p-6 border-b border-[#30363d]">
             <h1 class="text-xl font-bold text-[#58a6ff]">IT Dashboard</h1>
-            <p class="text-sm text-[#8b949e] mt-1"><%= current_user.name %></p>
+            <%= link_to edit_user_registration_path, class: "flex items-center space-x-3 mt-3 group" do %>
+              <% if current_user.avatar.attached? %>
+                <%= image_tag url_for(current_user.avatar), class: "w-9 h-9 rounded-full object-cover border border-[#30363d] group-hover:border-[#58a6ff] transition-colors flex-shrink-0", alt: current_user.name %>
+              <% else %>
+                <div class="w-9 h-9 rounded-full bg-[#21262d] border border-[#30363d] group-hover:border-[#58a6ff] flex items-center justify-center flex-shrink-0 transition-colors">
+                  <span class="text-sm font-bold text-[#58a6ff]"><%= current_user.name&.first&.upcase %></span>
+                </div>
+              <% end %>
+              <span class="text-sm text-[#8b949e] group-hover:text-[#c9d1d9] transition-colors truncate"><%= current_user.name %></span>
+            <% end %>
           </div>
 
           <nav class="flex-1 p-4 space-y-2">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: { registrations: "users/registrations" }
 
   # Root path
   root "dashboard#index"


### PR DESCRIPTION
- Agrega `has_one_attached :avatar` al modelo User
- Crea controlador personalizado Users::RegistrationsController para permitir el parámetro :avatar en Devise
- Actualiza rutas para usar el controlador personalizado
- Rediseña la vista de edición de perfil con Tailwind (secciones de foto, info de cuenta, cambio de contraseña)
- Muestra el avatar en el sidebar con fallback a inicial del nombre; clic lleva al perfil

https://claude.ai/code/session_01N3LibMHknHENPyXSobXoog